### PR TITLE
Feature/131 fix subcalendar for front

### DIFF
--- a/app/src/CalendarContext.jsx
+++ b/app/src/CalendarContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext } from 'react';
+import React, { createContext, useState, useContext, useRef, useCallback } from 'react';
 
 const CalendarContext = createContext();
 
@@ -7,20 +7,27 @@ export const useCalendar = () => useContext(CalendarContext);
 export const CalendarProvider = ({ children }) => {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [isExternalSelection, setIsExternalSelection] = useState(false);
+  const mainCalendarRef = useRef(null);
 
-  const setSelectedDateExternal = (date) => {
+  const setSelectedDateExternal = useCallback((date) => {
     setIsExternalSelection(true);
     setSelectedDate(date);
-  };
+    if (mainCalendarRef.current && mainCalendarRef.current.scrollToDate) {
+      mainCalendarRef.current.scrollToDate(date);
+    }
+  }, []);
 
   return (
     <CalendarContext.Provider value={{ 
       selectedDate, 
-      setSelectedDate, 
-      isExternalSelection, 
-      setSelectedDateExternal 
+      setSelectedDate,
+      isExternalSelection,
+      setSelectedDateExternal,
+      mainCalendarRef
     }}>
       {children}
     </CalendarContext.Provider>
   );
 };
+
+export default CalendarProvider;

--- a/app/src/CalendarContext.jsx
+++ b/app/src/CalendarContext.jsx
@@ -6,21 +6,29 @@ export const useCalendar = () => useContext(CalendarContext);
 
 export const CalendarProvider = ({ children }) => {
   const [selectedDate, setSelectedDate] = useState(new Date());
+  const [displayedMonth, setDisplayedMonth] = useState(new Date());
   const [isExternalSelection, setIsExternalSelection] = useState(false);
   const mainCalendarRef = useRef(null);
 
   const setSelectedDateExternal = useCallback((date) => {
     setIsExternalSelection(true);
     setSelectedDate(date);
+    setDisplayedMonth(date);
     if (mainCalendarRef.current && mainCalendarRef.current.scrollToDate) {
       mainCalendarRef.current.scrollToDate(date);
     }
+  }, []);
+
+  const changeDisplayedMonth = useCallback((date) => {
+    setDisplayedMonth(date);
   }, []);
 
   return (
     <CalendarContext.Provider value={{ 
       selectedDate, 
       setSelectedDate,
+      displayedMonth,
+      changeDisplayedMonth,
       isExternalSelection,
       setSelectedDateExternal,
       mainCalendarRef

--- a/app/src/components/SubCalendar.jsx
+++ b/app/src/components/SubCalendar.jsx
@@ -3,14 +3,14 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useCalendar } from '../CalendarContext.jsx';
 
 const SubCalendar = () => {
-  const { selectedDate, setSelectedDateExternal } = useCalendar();
+  const { selectedDate, setSelectedDateExternal, displayedMonth, changeDisplayedMonth } = useCalendar();
 
   const daysInMonth = (year, month) => new Date(year, month + 1, 0).getDate();
   const firstDayOfMonth = (year, month) => new Date(year, month, 1).getDay();
 
   const renderCalendar = () => {
-    const year = selectedDate.getFullYear();
-    const month = selectedDate.getMonth();
+    const year = displayedMonth.getFullYear();
+    const month = displayedMonth.getMonth();
     const days = daysInMonth(year, month);
     const firstDay = firstDayOfMonth(year, month);
 
@@ -37,13 +37,13 @@ const SubCalendar = () => {
   };
 
   const prevMonth = () => {
-    const newDate = new Date(selectedDate.getFullYear(), selectedDate.getMonth() - 1, 1);
-    setSelectedDateExternal(newDate);
+    const newDate = new Date(displayedMonth.getFullYear(), displayedMonth.getMonth() - 1, 1);
+    changeDisplayedMonth(newDate);
   };
 
   const nextMonth = () => {
-    const newDate = new Date(selectedDate.getFullYear(), selectedDate.getMonth() + 1, 1);
-    setSelectedDateExternal(newDate);
+    const newDate = new Date(displayedMonth.getFullYear(), displayedMonth.getMonth() + 1, 1);
+    changeDisplayedMonth(newDate);
   };
 
   return (
@@ -56,7 +56,7 @@ const SubCalendar = () => {
           <ChevronLeft size={24} />
         </button>
         <h2 className="text-xl font-semibold text-gray-800">
-          {selectedDate.getFullYear()}年 {selectedDate.getMonth() + 1}月
+          {displayedMonth.getFullYear()}年 {displayedMonth.getMonth() + 1}月
         </h2>
         <button 
           onClick={nextMonth} 

--- a/app/src/components/SubCalendar.jsx
+++ b/app/src/components/SubCalendar.jsx
@@ -48,23 +48,27 @@ const SubCalendar = () => {
 
   return (
     <div className="bg-white p-6 rounded-lg shadow w-full">
-      <div className="flex justify-between items-center mb-6">
-        <button 
-          onClick={prevMonth} 
-          className="bg-white text-blue-500 text-2xl font-bold w-10 h-10 rounded-full border border-blue-500 flex items-center justify-center hover:bg-blue-100 transition-colors duration-200"
-        >
-          <ChevronLeft size={24} />
-        </button>
-        <h2 className="text-xl font-semibold text-gray-800">
-          {displayedMonth.getFullYear()}年 {displayedMonth.getMonth() + 1}月
-        </h2>
-        <button 
-          onClick={nextMonth} 
-          className="bg-white text-blue-500 text-2xl font-bold w-10 h-10 rounded-full border border-blue-500 flex items-center justify-center hover:bg-blue-100 transition-colors duration-200"
-        >
-          <ChevronRight size={24} />
-        </button>
-      </div>
+      <div className="flex justify-center items-center mb-6">
+  <h2 className="text-xl font-semibold text-gray-800 mr-6">
+    {displayedMonth.getFullYear()}年 {displayedMonth.getMonth() + 1}月
+  </h2>
+  <div className="flex ml-4">
+    <button 
+      onClick={prevMonth} 
+      className="text-blue-500 bg-gray-100 w-10 h-10 flex items-center justify-center transition-all duration-200 ease-in-out mr-2 rounded-full hover:bg-gray-200 hover:text-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-opacity-50 !p-0 !border-0"
+      aria-label="前の月"
+    >
+      <ChevronLeft size={24} />
+    </button>
+    <button 
+      onClick={nextMonth} 
+      className="text-blue-500 bg-gray-100 w-10 h-10 flex items-center justify-center transition-all duration-200 ease-in-out rounded-full hover:bg-gray-200 hover:text-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-opacity-50 !p-0 !border-0"
+      aria-label="次の月"
+    >
+      <ChevronRight size={24} />
+    </button>
+  </div>
+</div>
       <div className="grid grid-cols-7 gap-2">
         {['日', '月', '火', '水', '木', '金', '土'].map(day => (
           <div key={day} className="text-center font-medium text-base text-gray-600">

--- a/app/src/components/SubCalendar.jsx
+++ b/app/src/components/SubCalendar.jsx
@@ -3,7 +3,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useCalendar } from '../CalendarContext.jsx';
 
 const SubCalendar = () => {
-  const { selectedDate, setSelectedDate } = useCalendar();
+  const { selectedDate, setSelectedDateExternal } = useCalendar();
 
   const daysInMonth = (year, month) => new Date(year, month + 1, 0).getDate();
   const firstDayOfMonth = (year, month) => new Date(year, month, 1).getDay();
@@ -37,11 +37,13 @@ const SubCalendar = () => {
   };
 
   const prevMonth = () => {
-    setSelectedDate(new Date(selectedDate.getFullYear(), selectedDate.getMonth() - 1, 1));
+    const newDate = new Date(selectedDate.getFullYear(), selectedDate.getMonth() - 1, 1);
+    setSelectedDateExternal(newDate);
   };
 
   const nextMonth = () => {
-    setSelectedDate(new Date(selectedDate.getFullYear(), selectedDate.getMonth() + 1, 1));
+    const newDate = new Date(selectedDate.getFullYear(), selectedDate.getMonth() + 1, 1);
+    setSelectedDateExternal(newDate);
   };
 
   return (


### PR DESCRIPTION
## サブカレンダーを追加
(Issue #32  )

### 変更内容
1. lucide-reactアイコンの実装
   - SubCalendar.jsx にChevronLeftとChevronRightアイコンを追加
   - アイコンの表示問題を解決

2. ボタンのスタイリング改善
   - ボタンのサイズを調整（w-10 h-10）
   - 背景色とテキスト色を変更（bg-gray-100, text-blue-500）
   - ホバー効果の追加（hover:bg-gray-200, hover:text-blue-600）

3. カレンダージャンプ機能の実装
   - CalendarContext.jsx にsetSelectedDateExternal関数を追加
   - MainCalendar.jsx にスクロール機能を実装
   - サブカレンダーでの日付選択時にメインカレンダーが対応する日付にスクロールする機能を追加