### PR TITLE
feature/57-add-cors-setting-for-front

### DIFF
--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -26,7 +26,15 @@ export default defineConfig({
   },
   server: {
     host: '0.0.0.0',
-    port: 5173
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      '/api': {
+        target: 'http://api:3000',
+        changeOrigin: true,
+        secure: false,
+      }
+    }
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## フロントエンドとバックエンドAPIの統合
[#57](https://github.com/Kuriyama301/osakana-calendar/issues/57)

### 変更内容

1. CORS設定の更新
   - `api/config/initializers/cors.rb` ファイルを更新
   - フロントエンドのオリジン（`http://localhost:5173`）を許可

2. Vite設定の調整
   - `front/app/vite.config.js` ファイルを更新
   - サーバー設定を追加し、ホストとポートを指定
   - APIへのプロキシ設定を追加

3. Docker Compose設定の修正
   - `docker-compose.yml` ファイルを更新
   - フロントエンドのポートマッピングを `5173:5173` に変更
   - 環境変数の設定を追加

4. 環境変数の設定
   - `.env.development` ファイルを更新
   - `API_URL` 環境変数を追加

5. フロントエンドのポート変更
   - アプリケーションへのアクセスを `http://localhost:5173/` に変更