### PR TITLE
Fix/138 calendar api for front

### DIFF
--- a/app/src/api/fish.js
+++ b/app/src/api/fish.js
@@ -5,7 +5,7 @@ export const getFishByDate = async (date) => {
     const formattedDate = date.toISOString().split('T')[0];
     console.log('Requesting fish data for date:', formattedDate);
     const response = await client.get(`/api/v1/calendar/fish?date=${formattedDate}`);
-    console.log('API Response:', response.data);
+    console.log('API Response:', JSON.stringify(response.data, null, 2));
     if (response.data.length > 0) {
       console.log('Sample fish data:', JSON.stringify(response.data[0], null, 2));
       console.log('Sample fish season:', JSON.stringify(response.data[0].fish_seasons[0], null, 2));

--- a/app/src/components/SeasonalFishModal.jsx
+++ b/app/src/components/SeasonalFishModal.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+console.log('VITE_API_URL:', import.meta.env.VITE_API_URL);
+
 const SeasonalFishModal = ({
   isOpen,
   onClose,
@@ -50,6 +52,7 @@ const SeasonalFishModal = ({
   );
 
   console.log("Filtered seasonal fish:", filteredFish);
+  console.log('Fish data:', JSON.stringify(filteredFish, null, 2));
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
@@ -65,11 +68,12 @@ const SeasonalFishModal = ({
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
             {filteredFish.map((fish) => (
               <div key={fish.id} className="text-center">
+                {console.log('Fish image_url:', fish.image_url)}
                 {fish.image_url ? (
-                  <img
-                    src={`http://localhost:3000${fish.image_url}`}
-                    alt={fish.name}
-                    className="w-full h-32 object-cover mb-2 rounded-lg"
+                  <img 
+                    src={`${import.meta.env.VITE_API_URL}${fish.image_url}`} 
+                    alt={fish.name} 
+                    className="w-full h-40 object-cover rounded-t-lg"
                   />
                 ) : (
                   <div className="w-full h-32 bg-gray-200 flex items-center justify-center mb-2 rounded-lg text-gray-800">

--- a/app/src/components/SeasonalFishModal.jsx
+++ b/app/src/components/SeasonalFishModal.jsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { X } from "lucide-react";
 
 console.log('VITE_API_URL:', import.meta.env.VITE_API_URL);
 
@@ -10,6 +11,19 @@ const SeasonalFishModal = ({
   isLoading,
   error,
 }) => {
+  const [isAnimating, setIsAnimating] = useState(false);
+  const [shouldRender, setShouldRender] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setShouldRender(true);
+      setTimeout(() => setIsAnimating(true), 10);
+    } else {
+      setIsAnimating(false);
+      setTimeout(() => setShouldRender(false), 300); // アニメーション時間と合わせる
+    }
+  }, [isOpen]);
+
   console.log("Rendering SeasonalFishModal", {
     isOpen,
     currentDate,
@@ -51,48 +65,81 @@ const SeasonalFishModal = ({
     })
   );
 
+  const handleClose = () => {
+    setIsAnimating(false);
+    setTimeout(onClose, 300); // アニメーション時間と合わせる
+  };
+
+  const handleModalClick = (e) => {
+    e.stopPropagation();
+  };
+
   console.log("Filtered seasonal fish:", filteredFish);
   console.log('Fish data:', JSON.stringify(filteredFish, null, 2));
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-      <div className="bg-white p-6 rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto text-gray-800">
-        <h2 className="text-2xl font-bold mb-4 text-gray-800">
-          {currentDate}の旬の魚
-        </h2>
-        {isLoading ? (
-          <p className="text-gray-800">データを読み込み中...</p>
-        ) : error ? (
-          <p className="text-red-500">{error}</p>
-        ) : filteredFish.length > 0 ? (
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-            {filteredFish.map((fish) => (
-              <div key={fish.id} className="text-center">
-                {console.log('Fish image_url:', fish.image_url)}
-                {fish.image_url ? (
-                  <img 
-                    src={`${import.meta.env.VITE_API_URL}${fish.image_url}`} 
-                    alt={fish.name} 
-                    className="w-full h-40 object-cover rounded-t-lg"
-                  />
-                ) : (
-                  <div className="w-full h-32 bg-gray-200 flex items-center justify-center mb-2 rounded-lg text-gray-800">
-                    画像なし
-                  </div>
-                )}
-                <p className="font-semibold text-gray-800">{fish.name}</p>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-gray-800">この日付の旬の魚はありません。</p>
-        )}
-        <button
-          onClick={onClose}
-          className="mt-6 bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition-colors"
-        >
-          閉じる
-        </button>
+    <div 
+      className={`fixed inset-0 bg-black flex items-center justify-center z-50 transition-all duration-300 ${
+        isAnimating ? 'bg-opacity-50' : 'bg-opacity-0'
+      }`}
+      onClick={handleClose}
+    >
+      <div 
+        className={`bg-white rounded-lg text-gray-800 relative transition-all duration-300 
+          w-full mx-4 sm:mx-8 md:mx-auto md:max-w-2xl 
+          max-h-[90vh] flex flex-col overflow-hidden
+          ${isAnimating ? 'scale-100 opacity-100' : 'scale-95 opacity-0'}`}
+        onClick={handleModalClick}
+      >
+        {/* ヘッダー部分 */}
+        <div className="sticky top-0 bg-white z-10 p-4 sm:p-6 border-b border-gray-200">
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-800 pr-8 sm:pr-12">
+            {currentDate}の旬の魚
+          </h2>
+          <button
+            onClick={handleClose}
+            className="absolute top-2 right-2 sm:top-4 sm:right-4 text-gray-600 bg-white hover:bg-gray-300 hover:text-gray-800 rounded-full p-2 transition-colors duration-200"
+            aria-label="Close modal"
+          >
+            <X size={24} />
+          </button>
+        </div>
+  
+        {/* スクロール可能なコンテンツ部分 */}
+        <div className="flex-grow overflow-y-auto scrollbar-hide p-4 sm:p-6 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:'none'] [scrollbar-width:'none']">
+          {isLoading ? (
+            <p className="text-gray-800">データを読み込み中...</p>
+          ) : error ? (
+            <p className="text-red-500">{error}</p>
+          ) : filteredFish.length > 0 ? (
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 sm:gap-6 px-0">
+              {filteredFish.map((fish) => (
+                <div key={fish.id} className="flex flex-col items-center justify-center text-center">
+                  {fish.image_url ? (
+                    <div className="w-32 h-32 sm:w-40 sm:h-40 flex items-center justify-center mb-2">
+                      <img 
+                        src={fish.image_url}
+                        alt={fish.name} 
+                        className="max-w-full max-h-full object-contain rounded-lg"
+                        onError={(e) => {
+                          console.error(`Failed to load image for ${fish.name}:`, e);
+                          e.target.src = 'path/to/fallback/image.jpg';
+                        }}
+                      />
+                    </div>
+                  ) : (
+                    <div className="w-32 h-32 sm:w-40 sm:h-40 bg-gray-200 flex items-center justify-center mb-2 rounded-lg text-gray-800">
+                      画像なし
+                    </div>
+                  )}
+                  <p className="font-semibold text-gray-800 text-sm sm:text-base">{fish.name}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-gray-800">この日付の旬の魚はありません。</p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -1,44 +1,50 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
-export default defineConfig({
-  plugins: [react()],
-  root: path.resolve(__dirname),
-  publicDir: path.resolve(__dirname, 'public'),
-  build: {
-    outDir: 'dist',
-    assetsDir: 'assets',
-    rollupOptions: {
-      input: {
-        main: path.resolve(__dirname, 'index.html'),
-      },
-      output: {
-        assetFileNames: (assetInfo) => {
-          let extType = assetInfo.name.split('.')[1];
-          if (/png|jpe?g|svg|gif|tiff|bmp|ico/i.test(extType)) {
-            extType = 'img';
-          }
-          return `assets/${extType}/[name][extname]`;
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    root: path.resolve(__dirname),
+    publicDir: path.resolve(__dirname, 'public'),
+    build: {
+      outDir: 'dist',
+      assetsDir: 'assets',
+      rollupOptions: {
+        input: {
+          main: path.resolve(__dirname, 'index.html'),
+        },
+        output: {
+          assetFileNames: (assetInfo) => {
+            let extType = assetInfo.name.split('.')[1];
+            if (/png|jpe?g|svg|gif|tiff|bmp|ico/i.test(extType)) {
+              extType = 'img';
+            }
+            return `assets/${extType}/[name][extname]`;
+          },
         },
       },
     },
-  },
-  server: {
-    host: '0.0.0.0',
-    port: 5173,
-    strictPort: true,
-    proxy: {
-      '/api': {
-        target: 'http://api:3000',
-        changeOrigin: true,
-        secure: false,
+    server: {
+      host: '0.0.0.0',
+      port: 5173,
+      strictPort: true,
+      proxy: {
+        '/api': {
+          target: 'http://api:3000',
+          changeOrigin: true,
+          secure: false,
+        }
       }
-    }
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
     },
-  },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
+    },
+    define: {
+      'process.env': env
+    }
+  }
 });


### PR DESCRIPTION
モーダルに魚情報を追加する
[#138](https://github.com/Kuriyama301/osakana-calendar/issues/138)
### 変更内容

1. ヘッダー部分の固定
   - ヘッダー部分に `sticky top-0` クラスを追加
   - コンテンツ部分を `flex-grow overflow-y-auto` で調整

2. 魚のイラスト表示の中央揃え
   - グリッドコンテナのクラスを調整：
     grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 sm:gap-6 px-0
   - 各魚のアイテムコンテナを調整：
     flex flex-col items-center justify-center text-center
   - イメージコンテナを調整：
     w-32 h-32 sm:w-40 sm:h-40 flex items-center justify-center mb-2
   - イメージのクラスを変更：
     max-w-full max-h-full object-contain rounded-lg