### PR TITLE
feature/138-add-fishdetails

### DIFF
--- a/app/src/components/Fish/FishDetails.jsx
+++ b/app/src/components/Fish/FishDetails.jsx
@@ -1,13 +1,92 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import SeasonTerm from './SeasonTerm';
 
-const FishDetails = ({ fish, onBack }) => {
+const FishDetails = ({ isOpen, onClose, fish }) => {
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsAnimating(true);
+    } else {
+      const timer = setTimeout(() => setIsAnimating(false), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  const handleClose = () => {
+    setIsAnimating(false);
+    setTimeout(onClose, 300);
+  };
+
+  if (!isAnimating && !isOpen) return null;
+
   return (
-    <div>
-      <button onClick={onBack} className="mb-4 text-blue-500 hover:text-blue-700">Back</button>
-      <img src={fish.imageUrl} alt={fish.name} className="w-full h-64 object-cover rounded-lg mb-4" />
-      <h3 className="text-2xl font-bold mb-2">{fish.name}</h3>
-      <p className="text-gray-700 mb-4">魚の説明がここに入ります。</p>
-      {/* 必要に応じて他の詳細情報を追加 */}
+    <div 
+      className={`fixed inset-0 bg-black transition-opacity duration-300 ease-in-out ${
+        isAnimating && isOpen ? 'bg-opacity-50' : 'bg-opacity-0'
+      } flex items-center justify-center z-50`}
+      onClick={handleClose}
+    >
+      <div 
+        className={`bg-white rounded-lg text-gray-800 relative w-full mx-4 sm:mx-8 md:mx-auto md:max-w-2xl max-h-[90vh] flex flex-col overflow-hidden transform transition-all duration-300 ease-in-out ${
+          isAnimating && isOpen ? 'scale-100 opacity-100' : 'scale-95 opacity-0'
+        }`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="sticky top-0 bg-white z-10 p-4 sm:p-6 border-b border-gray-200">
+          <h2 className="text-2xl sm:text-3xl font-bold text-gray-800 text-center">
+            {fish?.name}
+          </h2>
+          <button
+            onClick={handleClose}
+            className="absolute top-2 right-2 sm:top-4 sm:right-4 text-gray-600 bg-white hover:bg-gray-300 hover:text-gray-800 rounded-full p-2 transition-colors duration-200"
+            aria-label="Close modal"
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        <div className="flex-grow overflow-y-auto scrollbar-hide p-4 sm:p-6">
+          <div className="flex flex-col items-center">
+            {fish?.image_url ? (
+              <img 
+                src={fish.image_url}
+                alt={fish.name} 
+                className="w-full max-w-md h-auto object-contain rounded-lg mb-6"
+                onError={(e) => {
+                  console.error(`Failed to load image for ${fish.name}:`, e);
+                  e.target.src = '/path/to/fallback/image.jpg'; // フォールバック画像のパスを指定
+                }}
+              />
+            ) : (
+              <div className="w-full max-w-md h-48 bg-gray-200 flex items-center justify-center rounded-lg text-gray-800 mb-6">
+                画像なし
+              </div>
+            )}
+            
+            <div className="w-full">
+              <h3 className="text-xl font-semibold mb-2">旬の季節</h3>
+              {fish?.fish_seasons && fish.fish_seasons.length > 0 ? (
+                fish.fish_seasons.map((season, index) => (
+                  <SeasonTerm key={index} season={season} />
+                ))
+              ) : (
+                <p className="text-lg text-gray-700 mb-4">シーズン情報なし</p>
+              )}
+              
+              <h3 className="text-xl font-semibold mb-2 mt-6">原産地</h3>
+              <p className="text-lg text-gray-700 mb-4">{fish?.origin}</p>
+              
+              <h3 className="text-xl font-semibold mb-2">栄養</h3>
+              <p className="text-lg text-gray-700 mb-4">{fish?.nutrition}</p>
+              
+              <h3 className="text-xl font-semibold mb-2">特徴</h3>
+              <p className="text-lg text-gray-700">{fish?.features}</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/app/src/components/Fish/SeasonalFishModal.jsx
+++ b/app/src/components/Fish/SeasonalFishModal.jsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import SeasonTerm from './SeasonTerm';
+import FishDetails from './FishDetails';
 
 const SeasonalFishModal = ({
   isOpen,
@@ -10,17 +11,44 @@ const SeasonalFishModal = ({
   isLoading,
   error,
 }) => {
-  const filteredFish = seasonalFish; // useFishFilterを使用しない場合
+  const [selectedFish, setSelectedFish] = useState(null);
+  const [isFishDetailsOpen, setIsFishDetailsOpen] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
 
-  if (!isOpen) return null;
+  useEffect(() => {
+    if (isOpen) {
+      setIsAnimating(true);
+    } else {
+      const timer = setTimeout(() => setIsAnimating(false), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  const handleFishClick = (fish) => {
+    setSelectedFish(fish);
+    setIsFishDetailsOpen(true);
+  };
+
+  const handleCloseSeasonalFishModal = () => {
+    setIsAnimating(false);
+    setTimeout(onClose, 300);
+  };
+
+  const filteredFish = seasonalFish;
+
+  if (!isAnimating && !isOpen) return null;
 
   return (
     <div 
-      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-      onClick={onClose}
+      className={`fixed inset-0 bg-black transition-opacity duration-300 ease-in-out ${
+        isAnimating && isOpen ? 'bg-opacity-50' : 'bg-opacity-0'
+      } flex items-center justify-center z-50`}
+      onClick={handleCloseSeasonalFishModal}
     >
       <div 
-        className="bg-white rounded-lg text-gray-800 relative w-full mx-4 sm:mx-8 md:mx-auto md:max-w-2xl max-h-[90vh] flex flex-col overflow-hidden"
+        className={`bg-white rounded-lg text-gray-800 relative w-full mx-4 sm:mx-8 md:mx-auto md:max-w-2xl max-h-[90vh] flex flex-col overflow-hidden transform transition-all duration-300 ease-in-out ${
+          isAnimating && isOpen ? 'scale-100 opacity-100' : 'scale-95 opacity-0'
+        }`}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="sticky top-0 bg-white z-10 p-4 sm:p-6 border-b border-gray-200">
@@ -44,7 +72,11 @@ const SeasonalFishModal = ({
           ) : filteredFish.length > 0 ? (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 sm:gap-6">
               {filteredFish.map((fish) => (
-                <div key={fish.id} className="flex flex-col items-center justify-center text-center">
+                <div 
+                  key={fish.id} 
+                  className="flex flex-col items-center justify-center text-center cursor-pointer transition-transform duration-200 hover:scale-105"
+                  onClick={() => handleFishClick(fish)}
+                >
                   {fish.image_url ? (
                     <div className="w-32 h-32 sm:w-40 sm:h-40 flex items-center justify-center mb-2">
                       <img 
@@ -78,6 +110,12 @@ const SeasonalFishModal = ({
           )}
         </div>
       </div>
+
+      <FishDetails
+        isOpen={isFishDetailsOpen}
+        onClose={() => setIsFishDetailsOpen(false)}
+        fish={selectedFish}
+      />
     </div>
   );
 };


### PR DESCRIPTION
モーダルに魚情報を追加する [#138](https://github.com/Kuriyama301/osakana-calendar/issues/138)

## 変更内容

1. FishDetails コンポーネントの新規作成
   - 魚の詳細情報を表示するモーダルを実装
   - SeasonalFishModal から独立したコンポーネントとして作成

2. モーダルの構造とレイアウトの実装
   - ヘッダー、画像、詳細情報セクションを含む基本構造を設計
   - レスポンシブデザインレイアウトを実装

3. 魚の詳細情報の表示
   - 魚の名前、画像、旬の季節、原産地、栄養、特徴を表示
   - SeasonTerm コンポーネントを再利用して旬の季節情報を表示

4. モーダルの開閉ロジックの実装
   - isOpen プロップに基づいてモーダルの表示を実装
   - 閉じるボタンの実装

5. エラーハンドリングの追加
   - 画像読み込みエラーのチェック